### PR TITLE
feat: implement user delete

### DIFF
--- a/services/users/src/domain/error/user-email-taken-exception.ts
+++ b/services/users/src/domain/error/user-email-taken-exception.ts
@@ -1,0 +1,7 @@
+import { ConflictException } from '@nestjs/common';
+
+export class UserEmailTakenException extends ConflictException {
+  constructor() {
+    super('User email taken');
+  }
+}

--- a/services/users/src/domain/user-repository-interface.ts
+++ b/services/users/src/domain/user-repository-interface.ts
@@ -6,4 +6,5 @@ export interface UserRepositoryInterface {
   update: (user: User) => Promise<void>;
   findById: (id: string) => Promise<User | null>;
   findByEmail: (email: string) => Promise<User | null>;
+  delete: (user: User) => Promise<void>;
 }

--- a/services/users/src/infrastructure/model/user.schema.ts
+++ b/services/users/src/infrastructure/model/user.schema.ts
@@ -33,6 +33,13 @@ export class UserDefinition {
     default: Date.now,
   })
   createdAt!: Date;
+
+  @Prop({
+    index: true,
+    type: Date,
+    default: null,
+  })
+  deletedAt?: Date | null;
 }
 
 export type UserDocument = HydratedDocument<UserDefinition>;

--- a/services/users/src/infrastructure/model/user.schema.ts
+++ b/services/users/src/infrastructure/model/user.schema.ts
@@ -21,7 +21,6 @@ export class UserDefinition {
   @Prop({
     required: true,
     index: true,
-    unique: true,
   })
   email!: string;
 

--- a/services/users/src/infrastructure/mongoose-user-repository.spec.ts
+++ b/services/users/src/infrastructure/mongoose-user-repository.spec.ts
@@ -174,4 +174,25 @@ describe('MongooseUserRepository', () => {
       expect(user?.passwordHash).toEqual(userData.passwordHash);
     });
   });
+
+  describe('delete', () => {
+    const userData = {
+      id: uuid(),
+      email: 'john@gmail.com',
+      firstName: 'John',
+      lastName: 'Doe',
+      passwordHash: 'password',
+    };
+
+    beforeEach(async () => {
+      await userModel.create(userData);
+    });
+
+    it('deletes user', async () => {
+      await userRepository.delete(new User(userData));
+
+      const users = await userModel.find({ deletedAt: null }).exec();
+      expect(users).toHaveLength(0);
+    });
+  });
 });

--- a/services/users/src/infrastructure/mongoose-user-repository.ts
+++ b/services/users/src/infrastructure/mongoose-user-repository.ts
@@ -72,4 +72,8 @@ export class MongooseUserRepository implements UserRepositoryInterface {
         })
       : null;
   }
+
+  async delete(user: User): Promise<void> {
+    await this.userModel.updateOne({ id: user.id }, { deletedAt: new Date() });
+  }
 }

--- a/services/users/src/infrastructure/mongoose-user-repository.ts
+++ b/services/users/src/infrastructure/mongoose-user-repository.ts
@@ -21,7 +21,7 @@ export class MongooseUserRepository implements UserRepositoryInterface {
   }
 
   async findAll(): Promise<User[]> {
-    const users = await this.userModel.find().exec();
+    const users = await this.userModel.find({ deletedAt: null }).exec();
     return users.map((user) => {
       return new User({
         id: user.id,
@@ -46,7 +46,7 @@ export class MongooseUserRepository implements UserRepositoryInterface {
   }
 
   async findById(id: string): Promise<User | null> {
-    const user = await this.userModel.findOne({ id }).exec();
+    const user = await this.userModel.findOne({ id, deletedAt: null }).exec();
 
     return user !== null
       ? new User({
@@ -60,7 +60,9 @@ export class MongooseUserRepository implements UserRepositoryInterface {
   }
 
   async findByEmail(email: string): Promise<User | null> {
-    const user = await this.userModel.findOne({ email }).exec();
+    const user = await this.userModel
+      .findOne({ email, deletedAt: null })
+      .exec();
 
     return user !== null
       ? new User({

--- a/services/users/src/use-cases/create-user-use-case.spec.ts
+++ b/services/users/src/use-cases/create-user-use-case.spec.ts
@@ -3,12 +3,15 @@ import { providersEnum } from '../providers.enum.js';
 import { Test } from '@nestjs/testing';
 import { CreateUserUseCase } from './create-user-use-case.js';
 import { User } from '../domain/user.js';
+import { UserEmailTakenException } from '../domain/error/user-email-taken-exception.js';
 
 describe('create user use case', () => {
   const userRepositoryMockFactory = (): {
     create: jest.Mock;
+    findByEmail: jest.Mock<() => Promise<User | null>>;
   } => ({
     create: jest.fn(),
+    findByEmail: jest.fn(async () => null),
   });
 
   let userRepositoryMock: ReturnType<typeof userRepositoryMockFactory>;
@@ -38,8 +41,29 @@ describe('create user use case', () => {
     });
 
     expect(userRepositoryMock.create).toHaveBeenCalledTimes(1);
+    expect(userRepositoryMock.findByEmail).toHaveBeenCalledTimes(1);
 
     const user = userRepositoryMock.create.mock.calls[0][0];
     expect(user).toBeInstanceOf(User);
+  });
+
+  it('throws error when user email already taken', async () => {
+    const user = await User.createNewUser({
+      email: 'john@gmail.com',
+      firstName: 'John',
+      lastName: 'Doe',
+      password: 'password',
+    });
+
+    userRepositoryMock.findByEmail.mockResolvedValueOnce(user);
+
+    await expect(
+      useCase.execute({
+        email: 'john@gmail.com',
+        firstName: 'John2',
+        lastName: 'Doe2',
+        password: 'password2',
+      })
+    ).rejects.toThrowError(UserEmailTakenException);
   });
 });

--- a/services/users/src/use-cases/create-user-use-case.ts
+++ b/services/users/src/use-cases/create-user-use-case.ts
@@ -3,6 +3,7 @@ import { type UserRepositoryInterface } from '../domain/user-repository-interfac
 import { User } from '../domain/user.js';
 import { type UseCaseInterface } from './use-case-interface.js';
 import { providersEnum } from '../providers.enum.js';
+import { UserEmailTakenException } from '../domain/error/user-email-taken-exception.js';
 
 interface CreateUserUseCaseRequest {
   email: string;
@@ -31,6 +32,11 @@ export class CreateUserUseCase
   async execute(
     request: CreateUserUseCaseRequest
   ): Promise<CreateUserUseCaseResponse> {
+    const userInDb = await this.userRepository.findByEmail(request.email);
+    if (userInDb !== null) {
+      throw new UserEmailTakenException();
+    }
+
     const user = await User.createNewUser(request);
     await this.userRepository.create(user);
     return {

--- a/services/users/src/use-cases/delete-user-use-case.spec.ts
+++ b/services/users/src/use-cases/delete-user-use-case.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { providersEnum } from '../providers.enum.js';
+import { Test } from '@nestjs/testing';
+import { User } from '../domain/user.js';
+import { DeleteUserUseCase } from './delete-user-use-case.js';
+import { UserNotFoundException } from '../domain/error/user-not-found-exception.js';
+
+describe('delete user use case', () => {
+  const userRepositoryMockFactory = (): {
+    delete: jest.Mock;
+    findById: jest.Mock<() => Promise<User | null>>;
+  } => ({
+    delete: jest.fn(),
+    findById: jest.fn(async () => null),
+  });
+
+  let userRepositoryMock: ReturnType<typeof userRepositoryMockFactory>;
+  let useCase: DeleteUserUseCase;
+  let user: User;
+
+  beforeEach(async () => {
+    const testModule = await Test.createTestingModule({
+      providers: [
+        DeleteUserUseCase,
+        {
+          provide: providersEnum.UserRepository,
+          useFactory: userRepositoryMockFactory,
+        },
+      ],
+    }).compile();
+
+    userRepositoryMock = testModule.get(providersEnum.UserRepository);
+    useCase = testModule.get(DeleteUserUseCase);
+    user = await User.createNewUser({
+      email: 'john@gmail.com',
+      firstName: 'John',
+      lastName: 'Doe',
+      password: 'password',
+    });
+  });
+
+  it('deletes a user via repository', async () => {
+    userRepositoryMock.findById.mockResolvedValueOnce(user);
+
+    await useCase.execute({ id: user.id });
+
+    expect(userRepositoryMock.delete).toHaveBeenCalledTimes(1);
+    expect(userRepositoryMock.delete).toHaveBeenCalledWith(user);
+    expect(userRepositoryMock.findById).toHaveBeenCalledTimes(1);
+    expect(userRepositoryMock.findById).toHaveBeenCalledWith(user.id);
+  });
+
+  it('throws error when user is not found', async () => {
+    userRepositoryMock.findById.mockResolvedValueOnce(null);
+
+    await expect(useCase.execute({ id: user.id })).rejects.toThrowError(
+      UserNotFoundException
+    );
+  });
+});

--- a/services/users/src/use-cases/delete-user-use-case.ts
+++ b/services/users/src/use-cases/delete-user-use-case.ts
@@ -1,4 +1,4 @@
-import { Inject } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { providersEnum } from '../providers.enum.js';
 import { UserRepositoryInterface } from '../domain/user-repository-interface.js';
 import { type UseCaseInterface } from './use-case-interface.js';
@@ -10,6 +10,7 @@ interface DeleteUserUseCaseRequest {
 
 type DeleteUserUseCaseResponse = undefined;
 
+@Injectable()
 export class DeleteUserUseCase
   implements
     UseCaseInterface<DeleteUserUseCaseRequest, DeleteUserUseCaseResponse>

--- a/services/users/src/use-cases/delete-user-use-case.ts
+++ b/services/users/src/use-cases/delete-user-use-case.ts
@@ -1,0 +1,31 @@
+import { Inject } from '@nestjs/common';
+import { providersEnum } from '../providers.enum.js';
+import { UserRepositoryInterface } from '../domain/user-repository-interface.js';
+import { type UseCaseInterface } from './use-case-interface.js';
+import { UserNotFoundException } from '../domain/error/user-not-found-exception.js';
+
+interface DeleteUserUseCaseRequest {
+  id: string;
+}
+
+type DeleteUserUseCaseResponse = undefined;
+
+export class DeleteUserUseCase
+  implements
+    UseCaseInterface<DeleteUserUseCaseRequest, DeleteUserUseCaseResponse>
+{
+  constructor(
+    @Inject(providersEnum.UserRepository)
+    private readonly userRepository: UserRepositoryInterface
+  ) {}
+
+  async execute(request: DeleteUserUseCaseRequest): Promise<undefined> {
+    const user = await this.userRepository.findById(request.id);
+
+    if (user === null) {
+      throw new UserNotFoundException();
+    }
+
+    await this.userRepository.delete(user);
+  }
+}

--- a/services/users/src/user.module.ts
+++ b/services/users/src/user.module.ts
@@ -7,6 +7,11 @@ import {
   UserSchema,
 } from './infrastructure/model/user.schema.js';
 import { CreateUserUseCase } from './use-cases/create-user-use-case.js';
+import { AuthUserUseCase } from './use-cases/auth-user-use-case.js';
+import { DeleteUserUseCase } from './use-cases/delete-user-use-case.js';
+import { ListUsersUseCase } from './use-cases/list-users-use-case.js';
+import { ReadUserUseCase } from './use-cases/read-user-use-case.js';
+import { UpdateUserUseCase } from './use-cases/update-user-use-case.js';
 
 @Module({
   imports: [
@@ -20,7 +25,19 @@ import { CreateUserUseCase } from './use-cases/create-user-use-case.js';
       useClass: MongooseUserRepository,
     },
     CreateUserUseCase,
+    AuthUserUseCase,
+    DeleteUserUseCase,
+    ListUsersUseCase,
+    ReadUserUseCase,
+    UpdateUserUseCase,
   ],
-  exports: [CreateUserUseCase],
+  exports: [
+    CreateUserUseCase,
+    AuthUserUseCase,
+    DeleteUserUseCase,
+    ListUsersUseCase,
+    ReadUserUseCase,
+    UpdateUserUseCase,
+  ],
 })
 export class UserModule {}


### PR DESCRIPTION
- feat: implement user delete using soft delete
- feat: remove unique constraint in use schema
- feat: add guard in create user use case to avoid email duplication
- feat: add paranoid query of users
- feat: implement user delete use case
- feat: add new use cases to module

Closes #25
Also implements it in a paranoid way
