### PR TITLE
refactor: centralize secret in auth module definition

### DIFF
--- a/services/transactions/package-lock.json
+++ b/services/transactions/package-lock.json
@@ -19,7 +19,6 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "express": "^4.18.2",
-        "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.0.3",
         "reflect-metadata": "^0.1.14",
         "rxjs": "^7.8.1",
@@ -28,7 +27,6 @@
       "devDependencies": {
         "@nestjs/testing": "^10.3.0",
         "@types/express": "^4.17.21",
-        "@types/jsonwebtoken": "^9.0.5",
         "@types/supertest": "^2.0.16",
         "@types/uuid": "^9.0.7",
         "@typescript-eslint/eslint-plugin": "^6.14.0",

--- a/services/transactions/package.json
+++ b/services/transactions/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@nestjs/testing": "^10.3.0",
     "@types/express": "^4.17.21",
-    "@types/jsonwebtoken": "^9.0.5",
     "@types/supertest": "^2.0.16",
     "@types/uuid": "^9.0.7",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -58,7 +57,6 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "express": "^4.18.2",
-    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.0.3",
     "reflect-metadata": "^0.1.14",
     "rxjs": "^7.8.1",

--- a/services/transactions/src/interfaces/public-api/auth/auth-guard.ts
+++ b/services/transactions/src/interfaces/public-api/auth/auth-guard.ts
@@ -4,22 +4,12 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { type Request } from 'express';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  private readonly secret: string;
-
-  constructor(
-    private readonly jwtService: JwtService,
-    private readonly configService: ConfigService
-  ) {
-    this.secret =
-      this.configService.get<string>('PUBLIC_API_JWT_SECRET') ??
-      'default-secret';
-  }
+  constructor(private readonly jwtService: JwtService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -28,9 +18,7 @@ export class AuthGuard implements CanActivate {
       throw new UnauthorizedException();
     }
     try {
-      const payload = await this.jwtService.verifyAsync(token, {
-        secret: this.secret,
-      });
+      const payload = await this.jwtService.verifyAsync(token);
       request.user = payload;
     } catch {
       throw new UnauthorizedException();

--- a/services/transactions/src/interfaces/public-api/auth/auth.module.ts
+++ b/services/transactions/src/interfaces/public-api/auth/auth.module.ts
@@ -7,7 +7,7 @@ import { ConfigService } from '@nestjs/config';
   imports: [
     JwtModule.registerAsync({
       useFactory: (config: ConfigService) => ({
-        secret: config.get<string>('PUBLIC_API_JWT_SECRET'),
+        secret: config.get<string>('PUBLIC_API_JWT_SECRET') ?? 'secret',
       }),
       inject: [ConfigService],
     }),

--- a/services/transactions/src/interfaces/public-api/balance/balance-controller.spec.ts
+++ b/services/transactions/src/interfaces/public-api/balance/balance-controller.spec.ts
@@ -1,4 +1,3 @@
-import jwt from 'jsonwebtoken';
 import supertest from 'supertest';
 import { describe, beforeEach, it, expect, afterEach } from '@jest/globals';
 import { type NestApplication } from '@nestjs/core';
@@ -8,11 +7,12 @@ import {
   type TransactionModel,
 } from '../../../infrastructure/models/transaction.schema.js';
 import { Test, type TestingModule } from '@nestjs/testing';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
 import { TransactionsPublicApiModule } from '../transactions-public-api.module.js';
 import { ValidationPipe } from '@nestjs/common';
 import { v4 as uuid } from 'uuid';
+import { JwtService } from '@nestjs/jwt';
 
 describe('BalanceController', () => {
   let mongoServer: MongoMemoryServer;
@@ -38,12 +38,9 @@ describe('BalanceController', () => {
     transactionModel = testModule.get(
       getModelToken(TransactionDefinition.name)
     );
-    const configService = testModule.get(ConfigService);
-    jwtToken = jwt.sign(
-      { userId },
-      configService.get('PUBLIC_API_JWT_SECRET') ?? 'default-secret',
-      { expiresIn: '1h' }
-    );
+
+    const jwtService = testModule.get<JwtService>(JwtService);
+    jwtToken = jwtService.sign({ userId }, { expiresIn: '1h' });
 
     await testApp.init();
     await testApp.init();

--- a/services/transactions/src/interfaces/public-api/transactions/transactions-controller.spec.ts
+++ b/services/transactions/src/interfaces/public-api/transactions/transactions-controller.spec.ts
@@ -1,7 +1,6 @@
 import supertest from 'supertest';
-import jwt from 'jsonwebtoken';
 import { describe, beforeEach, afterEach, it, expect } from '@jest/globals';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { MongooseModule, getModelToken } from '@nestjs/mongoose';
 
 import { Test, type TestingModule } from '@nestjs/testing';
@@ -13,6 +12,7 @@ import {
   type TransactionModel,
 } from '../../../infrastructure/models/transaction.schema.js';
 import { v4 as uuid } from 'uuid';
+import { JwtService } from '@nestjs/jwt';
 
 describe('TransactionsController', () => {
   const userId = uuid();
@@ -37,12 +37,9 @@ describe('TransactionsController', () => {
     transactionModel = testModule.get(
       getModelToken(TransactionDefinition.name)
     );
-    const configService = testModule.get(ConfigService);
-    jwtToken = jwt.sign(
-      { userId },
-      configService.get('PUBLIC_API_JWT_SECRET') ?? 'default-secret',
-      { expiresIn: '1h' }
-    );
+
+    const jwtService = testModule.get<JwtService>(JwtService);
+    jwtToken = jwtService.sign({ userId }, { expiresIn: '1h' });
 
     await app.init();
   });


### PR DESCRIPTION
Avoids extra dependency on jsonwebtoken, though @nest/jwt depends on it
